### PR TITLE
Refactor: env variable to resemble LS's

### DIFF
--- a/lib/logstash/devutils/rspec/spec_helper.rb
+++ b/lib/logstash/devutils/rspec/spec_helper.rb
@@ -29,7 +29,7 @@ if RUBY_VERSION < "2.3"
   raise LoadError.new("Ruby >= 2.3.0 or later is required. (You are running: " + RUBY_VERSION + ")")
 end
 
-if level = (ENV["TEST_DEBUG"] || ENV['LOGGER_LEVEL'])
+if level = (ENV["TEST_DEBUG"] || ENV['LOG_LEVEL'])
   logger, level = level.split('=') # 'logstash.filters.grok=DEBUG'
   level, logger = logger, nil if level.nil? # only level given e.g. 'DEBUG'
   level = org.apache.logging.log4j.Level.toLevel(level, org.apache.logging.log4j.Level::WARN)


### PR DESCRIPTION
it's not exactly the same as LS's `LOG_LEVEL` path can be used the same way e.g. `LOG_LEVEL=debug` will do the same as within normal LS ...

do not think we need backwards compatibility that much here as we're the only consumer but if preferred we could keep `LOGGER_LEVEL` as well